### PR TITLE
Final fixes for multi-platform patches.

### DIFF
--- a/OpenHMDNet/Device.cs
+++ b/OpenHMDNet/Device.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace OpenHMDNet
 {

--- a/OpenHMDNet/Exceptions.cs
+++ b/OpenHMDNet/Exceptions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace OpenHMDNet
 {

--- a/OpenHMDNet/OpenHMD.cs
+++ b/OpenHMDNet/OpenHMD.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace OpenHMDNet
 {
@@ -12,31 +11,31 @@ namespace OpenHMDNet
         #region OpenHMDDll Imports
         public class OpenHMDWin
         {
-            [DllImport("libopenhmd.dll", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("openhmd.dll", CallingConvention = CallingConvention.Cdecl)]
             static extern public IntPtr ohmd_ctx_create();
 
-            [DllImport("libopenhmd.dll", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("openhmd.dll", CallingConvention = CallingConvention.Cdecl)]
             static extern public void ohmd_ctx_destroy(IntPtr ctxHandle);
 
-            [DllImport("libopenhmd.dll", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("openhmd.dll", CallingConvention = CallingConvention.Cdecl)]
             static extern public string ohmd_ctx_get_error(IntPtr ctxHandle);
 
-            [DllImport("libopenhmd.dll", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("openhmd.dll", CallingConvention = CallingConvention.Cdecl)]
             static extern public int ohmd_ctx_probe(IntPtr ctxHandle);
 
-            [DllImport("libopenhmd.dll", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("openhmd.dll", CallingConvention = CallingConvention.Cdecl)]
             static extern public IntPtr ohmd_list_open_device(IntPtr ctxHandle, int deviceIndex);
 
-            [DllImport("libopenhmd.dll", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("openhmd.dll", CallingConvention = CallingConvention.Cdecl)]
             static extern public IntPtr ohmd_list_gets(IntPtr ctxHandle, int deviceIndex, ohmd_string_value val);
 
-            [DllImport("libopenhmd.dll", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("openhmd.dll", CallingConvention = CallingConvention.Cdecl)]
             static extern public int ohmd_device_geti(IntPtr device, ohmd_int_value val, out int out_value);
 
-            [DllImport("libopenhmd.dll", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("openhmd.dll", CallingConvention = CallingConvention.Cdecl)]
             static extern public int ohmd_device_getf(IntPtr device, ohmd_float_value val, IntPtr out_value);
 
-            [DllImport("libopenhmd.dll", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("openhmd.dll", CallingConvention = CallingConvention.Cdecl)]
             static extern public void ohmd_ctx_update(IntPtr ctxHandle);
         }
 
@@ -93,7 +92,10 @@ namespace OpenHMDNet
             {
                 OpenHMDLin.ohmd_ctx_destroy(ctxHandle);
             }
-            throw new Exception("Critical error, please check if the OpenHMD library is loaded correctly.");
+            else
+            {
+                throw new Exception("Critical error, please check if the OpenHMD library is loaded correctly.");
+            }
         }
 
         static private string ohmd_ctx_get_error(IntPtr ctxHandle)
@@ -152,14 +154,12 @@ namespace OpenHMDNet
         {
             if (Utility.getCurrentPlatform() == Utility.currentPlatform.is_windows)
             {
-                //abstract opgeschreven.
                 int out_value;
-                if (OpenHMDLin.ohmd_device_geti(device, val, out out_value) >= 0)
+                if (OpenHMDWin.ohmd_device_geti(device, val, out out_value) >= 0)
                     return out_value;
             }
             else if (Utility.getCurrentPlatform() == Utility.currentPlatform.is_linux)
             {
-                //abstract opgeschreven.
                 int out_value;
                 if (OpenHMDLin.ohmd_device_geti(device, val, out out_value) >= 0)
                     return out_value;
@@ -190,7 +190,10 @@ namespace OpenHMDNet
             {
                 OpenHMDLin.ohmd_ctx_update(ctxHandle);
             }
-            throw new Exception("Critical error, please check if the OpenHMD library is loaded correctly.");
+            else
+            {
+                throw new Exception("Critical error, please check if the OpenHMD library is loaded correctly.");
+            }
         }
 
 

--- a/OpenHMDNet/OpenHMDNet.csproj
+++ b/OpenHMDNet/OpenHMDNet.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenHMDNet</RootNamespace>
     <AssemblyName>OpenHMDNet</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OpenHMDNet/Utility.cs
+++ b/OpenHMDNet/Utility.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 
 namespace OpenHMDNet

--- a/example/OpenHMDExample/App.config
+++ b/example/OpenHMDExample/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
-    </startup>
+        
+    <supportedRuntime version="v2.0.50727"/></startup>
 </configuration>

--- a/example/OpenHMDExample/OpenHMDExample.csproj
+++ b/example/OpenHMDExample/OpenHMDExample.csproj
@@ -9,12 +9,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenHMDExample</RootNamespace>
     <AssemblyName>OpenHMDExample</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/example/OpenHMDExample/Program.cs
+++ b/example/OpenHMDExample/Program.cs
@@ -61,5 +61,4 @@ namespace OpenHMDExample
             Console.ReadLine();
         }
     }
-    }
 }


### PR DESCRIPTION
- Changed name for default dll to openhmd.dll to match OpenHMD
- Fixed Example
- Fixed typo and returns in void functions
- Removed a include for .Net 3.5 compile
- Changed default .Net to 3.5 for Unity compatibility